### PR TITLE
Remove --api-key from batch command options

### DIFF
--- a/ci-cd/github-actions/.github/workflows/openlayer.yaml
+++ b/ci-cd/github-actions/.github/workflows/openlayer.yaml
@@ -17,6 +17,6 @@ jobs:
       - name: Install Your Requirements
         run: openlayer install
       - name: Generate Outputs
-        run: openlayer batch --api-key=${{ secrets.OPENLAYER_API_KEY }}
+        run: openlayer batch
       - name: Push Project Artifacts to Openlayer
         run: openlayer push --message ${{ github.event.head_commit.message }} --api-key=${{ secrets.OPENLAYER_API_KEY }}

--- a/ci-cd/github-actions/README.md
+++ b/ci-cd/github-actions/README.md
@@ -42,7 +42,7 @@ jobs:
       - name: Install Your Requirements
         run: openlayer install
       - name: Generate Outputs
-        run: openlayer batch --api-key=${{ secrets.OPENLAYER_API_KEY }}
+        run: openlayer batch
       - name: Push Project Artifacts to Openlayer
         run: openlayer push --message ${{ github.event.head_commit.message }} --api-key=${{ secrets.OPENLAYER_API_KEY }}
 ```


### PR DESCRIPTION
## Summary

- Removes the `--api-key` option from the `openlayer batch` command. 