### PR TITLE
OPEN-6224: Upgrade certifi

### DIFF
--- a/ci-cd/github-actions/requirements.txt
+++ b/ci-cd/github-actions/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.6.0
 anyio==4.2.0
 blinker==1.7.0
-certifi==2024.2.2
+certifi==2024.7.4
 click==8.1.7
 distro==1.9.0
 flask==3.0.2

--- a/python/llms/langchain/requirements.txt
+++ b/python/llms/langchain/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.6.0
 anyio==4.2.0
 blinker==1.7.0
-certifi==2024.2.2
+certifi==2024.7.4
 click==8.1.7
 distro==1.9.0
 flask==3.0.2

--- a/python/llms/openai-chatbot/requirements.txt
+++ b/python/llms/openai-chatbot/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.6.0
 anyio==4.2.0
 blinker==1.7.0
-certifi==2024.2.2
+certifi==2024.7.4
 click==8.1.7
 distro==1.9.0
 flask==3.0.2

--- a/python/llms/rag-qa/requirements.txt
+++ b/python/llms/rag-qa/requirements.txt
@@ -1,7 +1,7 @@
 annotated-types==0.6.0
 anyio==4.2.0
 blinker==1.7.0
-certifi==2024.2.2
+certifi==2024.7.4
 click==8.1.7
 distro==1.9.0
 flask==3.0.2


### PR DESCRIPTION
# Summary

Looks like there was some drama with a root certificate issuer and it is no longer trusted - https://groups.google.com/a/mozilla.org/g/dev-security-policy/c/XpknYMPO8dI

https://github.com/openlayer-ai/templates/security/dependabot/29
https://github.com/openlayer-ai/templates/security/dependabot/30
https://github.com/openlayer-ai/templates/security/dependabot/31
https://github.com/openlayer-ai/templates/security/dependabot/32

Shouldn't be a breaking change since it just works with certificates.