### PR TITLE
fix: remove local path from openai-chatbot install command

### DIFF
--- a/python/llms/openai-chatbot/openlayer.json
+++ b/python/llms/openai-chatbot/openlayer.json
@@ -3,7 +3,7 @@
   "model": {
     "modelType": "full",
     "runtime": "python_3_10",
-    "installCommand": "pip install uv; VIRTUAL_ENV=$(python -c 'import sys; print(sys.prefix)') uv pip install -r app/model/requirements.txt; uv pip install -e /Users/rishabramanathan/projects/openlayer-repos/openlayer-python",
+    "installCommand": "pip install uv; VIRTUAL_ENV=$(python -c 'import sys; print(sys.prefix)') uv pip install -r app/model/requirements.txt",
     "batchCommand": "python openlayer_run.py --dataset-path {{ path }} --output-dir {{ outputDirectory }}/{{ name }}",
     "outputDirectory": "output"
   },


### PR DESCRIPTION
## Summary

- Removes a local path that slipped into the `installCommand` for the `openai-chatbot` template.